### PR TITLE
ADM-9: Add core listing analytics events (view/contact/report)

### DIFF
--- a/src/app/listing/[id]/page.tsx
+++ b/src/app/listing/[id]/page.tsx
@@ -39,9 +39,15 @@ export default function ListingDetailPage() {
   useEffect(() => {
     if (listing) {
       incrementView({ id: listingId });
+      trackEvent("listing_viewed", {
+        listingId,
+        title: listing.title,
+        category: listing.category,
+        price: listing.price,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [listingId]);
+  }, [listingId, listing?._id]);
 
   const handleIWantThis = useCallback(async () => {
     if (!currentUser) {
@@ -50,6 +56,8 @@ export default function ListingDetailPage() {
       return;
     }
     try {
+      trackEvent("contact_clicked", { listingId, title: listing?.title, price: listing?.price });
+      // keep legacy event for existing dashboards during migration window
       trackEvent("i_want_this_clicked", { listingId, title: listing?.title, price: listing?.price });
       const convId = await getOrCreateConversation({ listingId });
       router.push(`/messages/${convId}`);
@@ -305,9 +313,11 @@ export default function ListingDetailPage() {
                 return;
               }
               const reason = prompt("Why are you reporting this listing?\n\n• Spam or scam\n• Inappropriate content\n• Prohibited item\n• Other");
-              if (!reason) return;
+              const trimmedReason = reason?.trim();
+              if (!trimmedReason) return;
               try {
-                await reportListing({ id: listingId, reason });
+                await reportListing({ id: listingId, reason: trimmedReason });
+                trackEvent("listing_reported", { listingId, reason: trimmedReason });
                 alert("Report submitted. Thank you!");
               } catch (e: any) {
                 alert(e.message?.includes("already reported") ? "You already reported this listing" : "Failed to submit report");


### PR DESCRIPTION
## Summary
Reintroduces ADM-9 analytics event wiring through proper PR review flow.

## Changes
- add `listing_viewed` event on listing page load
- add canonical `contact_clicked` event on "I Want This" action
- add `listing_reported` event on successful report submit
- trim report reason before submit/event capture
- keep legacy `i_want_this_clicked` event during migration window

## Why
Ensures key conversion/safety events are captured consistently for launch dashboards while preserving backward compatibility for existing charts.

## Validation
- `npm run build` passes locally

Refs #10

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires three PostHog analytics events (`listing_viewed`, `contact_clicked`, `listing_reported`) into the listing detail page, trims the report reason before submission, and preserves the legacy `i_want_this_clicked` event for backward compatibility with existing dashboards.

**Key changes:**
- `listing_viewed` is emitted inside the `useEffect` once the Convex query resolves, using `listing?._id` as a dependency to avoid firing on every re-render
- `contact_clicked` (and legacy `i_want_this_clicked`) are emitted in `handleIWantThis` before the async `getOrCreateConversation` call
- `listing_reported` is correctly emitted after `await reportListing(...)` succeeds
- Report `reason` is now `.trim()`-ed before being passed to both the mutation and the analytics event

**Issues found:**
- **Logic bug**: `contact_clicked` and `i_want_this_clicked` are tracked before `getOrCreateConversation` resolves. A thrown error (network failure, auth issue, etc.) will still record the event in PostHog, inflating contact metrics with failed attempts. This is inconsistent with `listing_reported`, which is correctly placed after success.

<h3>Confidence Score: 2/5</h3>

- Low confidence to merge due to data quality bug in contact event tracking.
- The change is narrow and isolated to one file. No user-facing behavior is broken—the logic for reporting, messaging, and view counting all still works. However, there is a confirmed data quality issue: `contact_clicked` fires before the async action completes, so network failures or auth errors still record contact events, inflating metrics with failed attempts. This is inconsistent with `listing_reported`, which is correctly placed after success. The fix is straightforward (move events after the `await`), which is why the score is 2 rather than lower.
- src/app/listing/[id]/page.tsx — specifically the event tracking order in `handleIWantThis` (lines 59–62).

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ListingPage
    participant PostHog
    participant Convex

    Note over ListingPage,Convex: listing_viewed flow
    ListingPage->>Convex: useQuery listings.get(listingId)
    Convex-->>ListingPage: listing data (listing?._id defined)
    ListingPage->>Convex: incrementView({ id: listingId })
    ListingPage->>PostHog: trackEvent("listing_viewed", {...})

    Note over User,Convex: contact_clicked flow (current — ⚠️ event fires before action)
    User->>ListingPage: clicks "I Want This"
    ListingPage->>PostHog: trackEvent("contact_clicked", {...}) ⚠️
    ListingPage->>PostHog: trackEvent("i_want_this_clicked", {...}) ⚠️
    ListingPage->>Convex: getOrCreateConversation({ listingId })
    alt success
        Convex-->>ListingPage: convId
        ListingPage->>User: router.push /messages/convId
    else failure
        Convex-->>ListingPage: throws error
        ListingPage->>User: alert(error) — but events already fired!
    end

    Note over User,Convex: listing_reported flow (correct — event fires after success)
    User->>ListingPage: clicks report flag
    ListingPage->>Convex: reportListing({ id, reason: trimmedReason })
    Convex-->>ListingPage: success
    ListingPage->>PostHog: trackEvent("listing_reported", { reason }) ✅
    ListingPage->>User: alert("Report submitted")
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/listing/[id]/page.tsx`, line 58-67 ([link](https://github.com/shimizu-technology/exchange/blob/c34631c753db1b8ca1c7d751d50f62430725926c/src/app/listing/[id]/page.tsx#L58-L67)) 

   `contact_clicked` and `i_want_this_clicked` are tracked at the top of the try block (lines 59–61), before `await getOrCreateConversation(...)` resolves (line 62). If `getOrCreateConversation` throws—due to network failure, auth issue, or any other error—these events are already recorded in PostHog, inflating contact metrics with failed attempts.

   This is inconsistent with how `listing_reported` is wired in the same PR (lines 319–320), where the event is correctly placed *after* the successful `await reportListing(...)` call. For data quality, both patterns should match.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: c34631c</sub>

<!-- /greptile_comment -->